### PR TITLE
Fix the URL of ES5 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ https://cdn.jsdelivr.net/npm/joshjs@1.0.0/dist/josh.es5.min.js
 https://unpkg.com/joshjs@1.0.0/dist/josh.min.js
 
 //ES5
-https://unpkg.com/joshjs@1.0.0/dist/josh.min.js
+https://unpkg.com/joshjs@1.0.0/dist/josh.es5.min.js
 ```
 
 ## Usage


### PR DESCRIPTION
Thanks for the library, Al Mamun!  

Currently, both ES6 and ES5 versions have the same UNPKG URL. 
This PR fixes the ES5 link.   