### PR TITLE
Fix a bug that treated an empty node list as a node

### DIFF
--- a/src/josh.js
+++ b/src/josh.js
@@ -62,7 +62,7 @@ class Josh {
   }
   //Adding css to DOM
   addCss(targetElm) {
-    if (targetElm.length > 0) {
+    if (targetElm instanceof NodeList) {
       targetElm.forEach((elm) => {
         this.cssUtil(elm);
       });
@@ -91,7 +91,7 @@ class Josh {
           threshold: this.offset,
         }
       );
-      if (domElement.length > 0) {
+      if (domElement instanceof NodeList) {
         //Observing every element
         domElement.forEach((animItem) => {
           intetsectObserver.observe(animItem);


### PR DESCRIPTION
I found a title bug and fixed it.
I am not familiar with js and have not been able to generate sources for es5 and es6.

Thank you.